### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Hercules
 
 [![Build Status](https://travis-ci.org/twneale/hercules.svg?branch=master)](https://travis-ci.org/twneale/hercules)
 [![Coverage Status](https://coveralls.io/repos/twneale/hercules/badge.png?branch=master)](https://coveralls.io/r/twneale/hercules?branch=master)
-[![Latest Version](https://pypip.in/version/hercules/badge.png)](https://pypi.python.org/pypi/hercules/)
-[![Download Format](https://pypip.in/format/hercules/badge.png)](https://pypi.python.org/pypi/hercules/)
+[![Latest Version](https://img.shields.io/pypi/v/hercules.svg)](https://pypi.python.org/pypi/hercules/)
+[![Download Format](https://img.shields.io/pypi/format/hercules.svg)](https://pypi.python.org/pypi/hercules/)
 
 Random utils I use everywhere, mostly consisting of Activestate recipes.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20hercules))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `hercules`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.